### PR TITLE
Add kubernetes deployment yamls

### DIFF
--- a/kubernetes/deployments/folio-mod-auth-token-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-auth-token-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-auth-token
+  labels:
+    run: folio-mod-auth-token
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-auth-token
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-auth-token
+  namespace: default
+  labels:
+    run: folio-mod-auth-token
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-auth-token
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-auth-token
+    spec:
+      containers:
+        - name: folio-mod-auth-token
+          image: folioci/mod-auth-token
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-circulation-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-circulation-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-circulation
+  labels:
+    run: folio-mod-circulation
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-circulation
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-circulation
+  namespace: default
+  labels:
+    run: folio-mod-circulation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-circulation
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-circulation
+    spec:
+      containers:
+        - name: folio-mod-circulation
+          image: folioci/mod-circulation
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-circulation-storage-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-circulation-storage-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-circulation-storage
+  labels:
+    run: folio-mod-circulation-storage
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-circulation-storage
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-circulation-storage
+  namespace: default
+  labels:
+    run: folio-mod-circulation-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-circulation-storage
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-circulation-storage
+    spec:
+      containers:
+        - name: folio-mod-circulation-storage
+          image: folioci/mod-circulation-storage
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-configuration-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-configuration-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-configuration
+  labels:
+    run: folio-mod-configuration
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-configuration
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-configuration
+  namespace: default
+  labels:
+    run: folio-mod-configuration
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-configuration
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-configuration
+    spec:
+      containers:
+        - name: folio-mod-configuration
+          image: folioci/mod-configuration
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-inventory-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-inventory-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-inventory
+  labels:
+    run: folio-mod-inventory
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-inventory
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-inventory
+  namespace: default
+  labels:
+    run: folio-mod-inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-inventory
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-inventory
+    spec:
+      containers:
+        - name: folio-mod-inventory
+          image: folioci/mod-inventory
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-inventory-storage-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-inventory-storage-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-inventory-storage
+  labels:
+    run: folio-mod-inventory-storage
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-inventory-storage
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-inventory-storage
+  namespace: default
+  labels:
+    run: folio-mod-inventory-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-inventory-storage
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-inventory-storage
+    spec:
+      containers:
+        - name: folio-mod-inventory-storage
+          image: folioci/mod-inventory-storage
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-kb-ebsco-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-kb-ebsco-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-kb-ebsco
+  labels:
+    run: folio-mod-kb-ebsco
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-kb-ebsco
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-kb-ebsco
+  namespace: default
+  labels:
+    run: folio-mod-kb-ebsco
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-kb-ebsco
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-kb-ebsco
+    spec:
+      containers:
+        - name: folio-mod-kb-ebsco
+          image: thefrontside/mod-kb-ebsco
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-kb-ebsco-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-kb-ebsco-deployment.yaml
@@ -48,6 +48,18 @@ spec:
                 secretKeyRef:
                   name: cloudsql-db-credentials
                   key: password
+            - name: EBSCO_RESOURCE_MANAGEMENT_API_BASE_URL
+              value: https://sandbox.ebsco.io
+            - name: EBSCO_RESOURCE_MANAGEMENT_API_CUSTOMER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: rmapi-secret
+                  key: customer_id
+            - name: EBSCO_RESOURCE_MANAGEMENT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rmapi-secret
+                  key: api_key
         - image: gcr.io/cloudsql-docker/gce-proxy:1.09
           name: cloudsql-proxy
           command: ["/cloud_sql_proxy", "--dir=/cloudsql",

--- a/kubernetes/deployments/folio-mod-login-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-login-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-login
+  labels:
+    run: folio-mod-login
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-login
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-login
+  namespace: default
+  labels:
+    run: folio-mod-login
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-login
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-login
+    spec:
+      containers:
+        - name: folio-mod-login
+          image: thefrontside/mod-login
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-login-saml-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-login-saml-deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-login-saml
+  labels:
+    run: folio-mod-login-saml
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-login-saml
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-login-saml
+  namespace: default
+  labels:
+    run: folio-mod-login-saml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-login-saml
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-login-saml
+    spec:
+      containers:
+        - name: folio-mod-login-saml
+          image: folioci/mod-login-saml
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1

--- a/kubernetes/deployments/folio-mod-permissions-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-permissions-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-permissions
+  labels:
+    run: folio-mod-permissions
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-permissions
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-permissions
+  namespace: default
+  labels:
+    run: folio-mod-permissions
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-permissions
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-permissions
+    spec:
+      containers:
+        - name: folio-mod-permissions
+          image: folioci/mod-permissions
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/folio-mod-users-bl-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-users-bl-deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-users-bl
+  labels:
+    run: folio-mod-users-bl
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-users-bl
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata: 
+  name: folio-mod-users-bl
+  namespace: default
+  labels:
+    run: folio-mod-users-bl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-users-bl
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-users-bl
+    spec:
+      containers:
+        - name: folio-mod-users-bl
+          image: folioci/mod-users-bl
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1

--- a/kubernetes/deployments/folio-mod-users-deployment.yaml
+++ b/kubernetes/deployments/folio-mod-users-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: folio-mod-users
+  labels:
+    run: folio-mod-users
+spec:
+  ports:
+  - port: 8081
+  selector:
+    run: folio-mod-users
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: folio-mod-users
+  namespace: default
+  labels:
+    run: folio-mod-users
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: folio-mod-users
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: folio-mod-users
+    spec:
+      containers:
+        - name: folio-mod-users
+          image: folioci/mod-users
+          env:
+            - name: DB_HOST
+              value: localhost
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_DATABASE
+              value: folio
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+        - image: gcr.io/cloudsql-docker/gce-proxy:1.09
+          name: cloudsql-proxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                      "-instances=okapi-173322:us-east1:folio-okapi=tcp:5432",
+                      "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+              - name: cloudsql-instance-credentials
+                mountPath: /secrets/cloudsql
+                readOnly: true
+              - name: ssl-certs
+                mountPath: /etc/ssl/certs
+              - name: cloudsql
+                mountPath: /cloudsql
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          secretName: cloudsql-instance-credentials
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: cloudsql
+        emptyDir:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+

--- a/kubernetes/deployments/ingress-config-map-deployment.yaml
+++ b/kubernetes/deployments/ingress-config-map-deployment.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-ingress-controller-conf
+  labels:
+    k8s-app: nginx-ingress-lb
+data:
+  enable-vts-status: 'true'
+  9130: "default/okapi-cluster:80"

--- a/kubernetes/deployments/ingress-controller-deployment.yaml
+++ b/kubernetes/deployments/ingress-controller-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ingress-controller
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      name: http
+      protocol: TCP
+    - port: 443
+      name: https
+      protocol: TCP
+  selector:
+    k8s-app: nginx-ingress-lb
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+        k8s-app: nginx-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+    spec:
+      containers:
+        - name: nginx-ingress-controller
+          image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
+          args:
+             - /nginx-ingress-controller
+             - --default-backend-service=default/default-backend
+             - --default-ssl-certificate=$(POD_NAMESPACE)/tls-certificate
+          env:
+             - name: POD_NAME
+               valueFrom:
+                 fieldRef:
+                   fieldPath: metadata.name
+             - name: POD_NAMESPACE
+               valueFrom:
+                 fieldRef:
+                   fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
+          livenessProbe:  # Optional
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          resources:  # Optional
+            requests:
+              memory: "10Mi"
+            limits:
+              memory: "100Mi"

--- a/kubernetes/deployments/ingress-default-backend-deployment.yaml
+++ b/kubernetes/deployments/ingress-default-backend-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-backend
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: default-backend
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: default-backend
+spec:
+  replicas: 1
+  selector:
+    app: default-backend
+  template:
+    metadata:
+      labels:
+        app: default-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-backend
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/kubernetes/deployments/ingress.yaml
+++ b/kubernetes/deployments/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: folio-test-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - okapi.frontside.io
+    secretName: okapi-tls-secret
+  backend:
+   serviceName: okapi-cluster
+   servicePort: 80
+  rules:
+  - host: okapi.frontside.io
+  - http:
+      paths:
+      - path:
+        backend:
+          serviceName: okapi-cluster
+          servicePort: 80

--- a/kubernetes/deployments/okapi-deployment.yaml
+++ b/kubernetes/deployments/okapi-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           value: "5432"
         - name: DB_DATABASE
           value: folio
-        - name: DB_USER
+        - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
               key: username

--- a/kubernetes/deployments/okapi-deployment.yaml
+++ b/kubernetes/deployments/okapi-deployment.yaml
@@ -6,8 +6,7 @@ metadata:
   name: okapi-cluster
   namespace: default
 spec:
-  type: LoadBalancer
-  loadBalancerIP: 104.196.172.62
+  type: NodePort
   ports:
     port: 80
     protocol: TCP

--- a/kubernetes/deployments/okapi-deployment.yaml
+++ b/kubernetes/deployments/okapi-deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: okapi-cluster
+  name: okapi-cluster
+  namespace: default
+spec:
+  type: LoadBalancer
+  ports:
+    port: 80
+    protocol: TCP
+    targetPort: 9130
+  selector:
+    run: okapi-cluster 
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: okapi-cluster
+  name: okapi-cluster
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: okapi-cluster
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: okapi-cluster
+    spec:
+      containers:
+      - env:
+        - name: DB_HOST
+          value: localhost
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_DATABASE
+          value: folio
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: cloudsql-db-credentials
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: cloudsql-db-credentials
+        image: gcr.io/okapi-173322/okapi-cluster-postgres:v5
+        imagePullPolicy: Always
+        name: okapi-cluster
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - command:
+        - /cloud_sql_proxy
+        - --dir=/cloudsql
+        - -instances=okapi-173322:us-east1:folio-okapi=tcp:5432
+        - -credential_file=/secrets/cloudsql/credentials.json
+        image: gcr.io/cloudsql-docker/gce-proxy:1.09
+        imagePullPolicy: IfNotPresent
+        name: cloudsql-proxy
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /secrets/cloudsql
+          name: cloudsql-instance-credentials
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs
+        - mountPath: /cloudsql
+          name: cloudsql
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: cloudsql-instance-credentials
+        secret:
+          defaultMode: 420
+          secretName: cloudsql-instance-credentials
+      - hostPath:
+          path: /etc/ssl/certs
+        name: ssl-certs
+      - emptyDir: {}
+        name: cloudsql

--- a/kubernetes/deployments/okapi-deployment.yaml
+++ b/kubernetes/deployments/okapi-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 spec:
   type: LoadBalancer
+  loadBalancerIP: 104.196.172.62
   ports:
     port: 80
     protocol: TCP


### PR DESCRIPTION
Kubernetes deployment yamls are needed to stand up the cluster from scratch. Here we will create both the Deployments and Services necessary for internal pod to pod communication and external communication into the cluster. On Google Container Engine we created a static IP address that is used for the External Load Balancer (ELB) Service for entry into the the cluster. That static IP is necessary to give a constant IP address so during Service creation Kubernetes can link the External Load Balancer to that IP. 