### PR TITLE
Update kube-lego to 1.6

### DIFF
--- a/kubernetes/ingress/lego/lego.yaml
+++ b/kubernetes/ingress/lego/lego.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kube-lego
-        image: jetstack/kube-lego:0.1.5
+        image: jetstack/kube-lego:0.1.6
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Purpose
 - 1.5 had a issue where it was hitting Let's Encrypt unnecessarily so updating to 1.6 fixes that bug.