### PR TITLE
Fix registry pull DNS resolution issue

### DIFF
--- a/folio.conf
+++ b/folio.conf
@@ -1,6 +1,6 @@
 sandbox:
   host: https://okapi-sandbox.frontside.io
-  registry: http://folio-registry.aws.indexdata.com
+  registry: http://folio-registry.aws.indexdata.com.
   tenant: fs
   context: gke_okapi-173322_us-central1-a_okapi-sandbox
   okapi:
@@ -41,7 +41,7 @@ sandbox:
     instance_credentials_secret: cloudsql-instance-credentials
 production:
   host: https://okapi.frontside.io
-  registry: http://folio-registry.aws.indexdata.com
+  registry: http://folio-registry.aws.indexdata.com.
   tenant: fs
   context: gke_okapi-173322_us-central1-a_okapi
   okapi:


### PR DESCRIPTION
## Purpose

When deploying a Okapi gateway and the modules that are needed for even the basic functional version of a Okapi cluster there needs to be a `PULL` to the registry that houses the list of all modules and their tagged container images. This `PULL` is used to assist in the dependency resolution that happens to ensure the modules that a user requested can all work together appropriately.

The `PULL` or request to the registry was failing due a `Search Domain Query Failed` which is DNS resolution issue. It was failing to resolve the 
 - original hostname: 
    - http://folio-registry.aws.indexdata.com 
      to 
    - http://folio-registry.aws.indexdata.com.google.internal

## Approach
Make sure the registry name is absolute fully-qualified (unambiguous) DNS domain name for the DNS resolution.
 - Add a `.` to the end of the registry name

## Learning
- This article will explain the reason for the dot further
  - http://www.dns-sd.org/trailingdotsindomainnames.html